### PR TITLE
Fix random seed negative index

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,10 @@ func main() {
 	fmt.Scan(&input)
 
 	// Modifying the seed with user input
-	seed = (seed + int64(input)) % 100
+       seed = (seed + int64(input)) % 100
+       if seed < 0 {
+               seed = -seed
+       }
 
 	// Selecting the strings based on modified seed
 	choice1 := superheroes[seed%int64(len(superheroes))]


### PR DESCRIPTION
## Summary
- handle negative values when computing the seed

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841c9a1f41c832e99c340c6234a7d10